### PR TITLE
Add unmanaged memory information to GC

### DIFF
--- a/api/clroni/clroni/Context.cs
+++ b/api/clroni/clroni/Context.cs
@@ -246,6 +246,8 @@
             Frame frame;
             int rc = NativeMethods.oni_read_frame(handle, out frame);
             if (rc < 0) { throw new ONIException(rc); }
+            var data_bytes = ((frame_t*)frame.DangerousGetHandle())->data_sz;
+            frame.addMemoryPressure(data_bytes);
             return frame;
         }
 

--- a/api/clroni/clroni/Frame.cs
+++ b/api/clroni/clroni/Frame.cs
@@ -19,6 +19,7 @@ namespace oni
         protected Frame()
         : base(true)
         {
+          
         }
 
         // Ideally, I would like this to be a "Span" into the existing, allocated frame
@@ -62,10 +63,17 @@ namespace oni
         //    // Copy the memory
         //    Buffer.MemoryCopy(data.ToPointer(), frame->data, num_bytes, data_size);
         //}
+        private long mempress = 0;
+        public void addMemoryPressure(long mem)
+        {
+            mempress += mem;
+            GC.AddMemoryPressure(mem);
+        }
 
         protected override bool ReleaseHandle()
         {
             lib.NativeMethods.oni_destroy_frame(handle);
+            GC.RemoveMemoryPressure(mempress);
             return true;
         }
 


### PR DESCRIPTION
Makes the Garbage collector aware of the unmanaged memory related to Frames, so it can take better decisions on when to release them.

This only affect read frames. We might need to tweak it a bit for created frames for writing.

I added a method that feels hacky, read the comments below for a discussion.